### PR TITLE
nixos/portmaster: init module

### DIFF
--- a/maintainers/maintainer-list.nix
+++ b/maintainers/maintainer-list.nix
@@ -18901,6 +18901,15 @@
     github = "snpschaaf";
     githubId = 105843013;
   };
+  sntx = {
+    email = "sntx.htqjd@simplelogin.com";
+    github = "Sntx626";
+    githubId = 48636286;
+    name = "sntx";
+    keys = [{
+      fingerprint = "0809 A274 05DE 37A1 6884 FD78 071E 9A01 90AA B7E9";
+    }];
+  };
   snyh = {
     email = "snyh@snyh.org";
     github = "snyh";

--- a/nixos/modules/services/networking/portmaster.nix
+++ b/nixos/modules/services/networking/portmaster.nix
@@ -1,0 +1,93 @@
+{ config
+, lib
+, pkgs
+, ...
+}:
+let
+  cfg = config.services.portmaster;
+in
+with lib; {
+  options.services.portmaster = {
+    enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        This option enables the portmaster-core daemon.
+      '';
+    };
+
+    devmode.enable = mkOption {
+      type = types.bool;
+      default = false;
+      description = lib.mdDoc ''
+        This option enables the portmaster-core devmode.
+
+        The devmode makes the Portmaster UI available at `127.0.0.1:817`.
+      '';
+    };
+
+    dataDir = mkOption {
+      type = types.path;
+      default = "/var/lib/portmaster";
+      description = lib.mdDoc ''
+        The directory where Portmaster stores its data files.
+      '';
+    };
+  };
+
+  config = mkIf cfg.enable {
+    systemd.services.portmaster = {
+      enable = true;
+      description = "Portmaster by Safing";
+      documentation = [ "https://safing.io" "https://docs.safing.io" ];
+
+      after = [ "network.target" ];
+      wantedBy = [ "multi-user.target" ];
+
+      path = with pkgs; [ iptables ];
+
+      preStart =
+        "${pkgs.portmaster}/bin/portmaster-start"
+        + " --data \"${cfg.dataDir}\""
+        + " update";
+
+      script =
+        "${pkgs.portmaster}/bin/portmaster-core"
+        + " --data \"${cfg.dataDir}\""
+        + optionalString cfg.devmode.enable " -devmode";
+
+      postStop =
+        "${pkgs.portmaster}/bin/portmaster-start"
+        + " --data \"${cfg.dataDir}\""
+        + " recover-iptables";
+
+      serviceConfig = {
+        Type = "simple";
+        Restart = "on-failure";
+        RestartSec = "10";
+        LockPersonality = "yes";
+        MemoryDenyWriteExecute = "yes";
+        NoNewPrivileges = "yes";
+        PrivateTmp = "yes";
+        PIDFile = "${cfg.dataDir}/core-lock.pid";
+        Environment = [ "LOGLEVEL=info" ];
+        ProtectSystem = "true";
+        ReadWritePaths = [ cfg.dataDir ];
+        RestrictAddressFamilies = "AF_UNIX AF_NETLINK AF_INET AF_INET6";
+        RestrictNamespaces = "yes";
+        ProtectHome = "read-only";
+        ProtectKernelTunables = "yes";
+        ProtectKernelLogs = "yes";
+        ProtectControlGroups = "yes";
+        PrivateDevices = "yes";
+        AmbientCapabilities = "cap_chown cap_kill cap_net_admin cap_net_bind_service cap_net_broadcast cap_net_raw cap_sys_module cap_sys_ptrace cap_dac_override cap_fowner cap_fsetid";
+        CapabilityBoundingSet = "cap_chown cap_kill cap_net_admin cap_net_bind_service cap_net_broadcast cap_net_raw cap_sys_module cap_sys_ptrace cap_dac_override cap_fowner cap_fsetid";
+        SystemCallArchitectures = "native";
+        SystemCallFilter = "@system-service @module";
+        SystemCallErrorNumber = "EPERM";
+      };
+    };
+  };
+
+  meta.maintainers = with maintainers; [ nyanbinary sntx ];
+}


### PR DESCRIPTION
## Description of changes

<!--
For package updates please link to a changelog or describe changes, this helps your fellow maintainers discover breaking updates.
For new packages please briefly describe the package or provide a link to its homepage.
-->

The previous force pull to the portmaster branch must have removed this module, this PR intents to re-add it.

## Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- Built on platform(s)
  - [x] x86_64-linux
  - [x] aarch64-linux
  - [ ] x86_64-darwin
  - [ ] aarch64-darwin
- For non-Linux: Is sandboxing enabled in `nix.conf`? (See [Nix manual](https://nixos.org/manual/nix/stable/command-ref/conf-file.html))
  - [ ] `sandbox = relaxed`
  - [ ] `sandbox = true`
- [ ] Tested, as applicable:
  - [NixOS test(s)](https://nixos.org/manual/nixos/unstable/index.html#sec-nixos-tests) (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
  - and/or [package tests](https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#package-tests)
  - or, for functions and "core" functionality, tests in [lib/tests](https://github.com/NixOS/nixpkgs/blob/master/lib/tests) or [pkgs/test](https://github.com/NixOS/nixpkgs/blob/master/pkgs/test)
  - made sure NixOS tests are [linked](https://nixos.org/manual/nixpkgs/unstable/#ssec-nixos-tests-linking) to the relevant packages
- [x] Tested compilation of all packages that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review rev HEAD"`. Note: all changes have to be committed, also see [nixpkgs-review usage](https://github.com/Mic92/nixpkgs-review#usage)
- [x] Tested basic functionality of all binary files (usually in `./result/bin/`)
- [24.11 Release Notes](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2411.section.md) (or backporting [23.11](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2311.section.md) and [24.05](https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2405.section.md) Release notes)
  - [ ] (Package updates) Added a release notes entry if the change is major or breaking
  - [ ] (Module updates) Added a release notes entry if the change is significant
  - [ ] (Module addition) Added a release notes entry if adding a new NixOS module
- [x] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/CONTRIBUTING.md).

<!--
To help with the large amounts of pull requests, we would appreciate your
reviews of other pull requests, especially simple package updates. Just leave a
comment describing what you have tested in the relevant package/service.
Reviewing helps to reduce the average time-to-merge for everyone.
Thanks a lot if you do!

List of open PRs: https://github.com/NixOS/nixpkgs/pulls
Reviewing guidelines: https://github.com/NixOS/nixpkgs/blob/master/pkgs/README.md#reviewing-contributions
-->

---

Add a :+1: [reaction] to [pull requests you find important].

[reaction]: https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/
[pull requests you find important]: https://github.com/NixOS/nixpkgs/pulls?q=is%3Aopen+sort%3Areactions-%2B1-desc
